### PR TITLE
Fixing path in individual Rscript.

### DIFF
--- a/trainbenchmark-reporting/individual.R
+++ b/trainbenchmark-reporting/individual.R
@@ -22,7 +22,7 @@ sizes[["Repair"]] = c("8k", "15k", "33k", "66k", "135k", "271k", "566k", "1.1M",
 toolList = read.csv("tool-list.csv", colClasses=c(rep("character",1)))
 
 # load the data
-tsvs = list.files("../results/", pattern = "recent/times-.*\\.csv", full.names = T, recursive = T)
+tsvs = list.files("../results/recent/", pattern = "times-.*\\.csv", full.names = T, recursive = T)
 l = lapply(tsvs, read.csv)
 times = rbindlist(l)
 


### PR DESCRIPTION
Pattern apparently only apply to the basename of the file.
Therefore, just list files in the "results/recent" directory, which is a symlink created when running a benchmark or an individual benchmark.
